### PR TITLE
Add annotation source to GO xref query

### DIFF
--- a/ensembl_genes/queries/gene_xrefs_go.sql
+++ b/ensembl_genes/queries/gene_xrefs_go.sql
@@ -9,6 +9,7 @@ SELECT
   xref.description AS go_label,
   GROUP_CONCAT(DISTINCT object_xref.linkage_annotation ORDER BY object_xref.linkage_annotation) AS go_evidence_codes,
   GROUP_CONCAT(DISTINCT xref.info_type ORDER BY xref.info_type) AS xref_info_types,
+  GROUP_CONCAT(DISTINCT xref.info_text ORDER BY xref.info_text) AS xref_info_texts,
   GROUP_CONCAT(DISTINCT transcript.stable_id ORDER BY transcript.stable_id) AS ensembl_transcript_ids
 FROM gene
 INNER JOIN transcript 


### PR DESCRIPTION
It would be helpful to have the GO xref annotation sources as well.  This was a quick addition, and the results look like:

<img width="478" alt="Screen Shot 2022-03-03 at 7 50 59 PM" src="https://user-images.githubusercontent.com/6130352/156678189-639d1770-e785-4581-a60b-3ccd703effcc.png">

